### PR TITLE
modify "this" for "use strict"

### DIFF
--- a/jquery.selectBox.js
+++ b/jquery.selectBox.js
@@ -18,7 +18,7 @@
      * @param {Object}             options
      * @constructor
      */
-    var SelectBox = this.SelectBox = function (select, options) {
+    var SelectBox = window.SelectBox = function (select, options) {
         if (select instanceof jQuery) {
             if (select.length > 0) {
                 select = select[0];


### PR DESCRIPTION
if someone use ES6 or Babel default transform, the js code will under the strict mode.so "this" will become "undefined".